### PR TITLE
Set subject values to nil when needed

### DIFF
--- a/lib/ruby-ares/parser.rb
+++ b/lib/ruby-ares/parser.rb
@@ -16,18 +16,16 @@ module RubyARES
 
         # Basic info
         doc.find('//D:VBAS').each do |node|
-          attrs = node.children()
-
           # Attributes of the subject
-          @status = node.find("D:ROR/D:SOR/D:SSU").to_a[0].content unless node.find('D:ROR/D:SOR/D:SSU').to_a.size == 0
-          @ic = node.find('D:ICO').to_a[0].content unless node.find('D:ICO').to_a.size == 0
-          @dic = node.find('D:DIC').to_a[0].content unless node.find('D:DIC').to_a.size == 0
-          @name = node.find('D:OF').to_a[0].content unless node.find('D:OF').to_a.size == 0
-          @legal_form = node.find('D:PF/D:NPF').to_a[0].content unless node.find('D:PF/D:NPF').to_a.size == 0
-          @legal_form_id = node.find('D:PF/D:KPF').to_a[0].content unless node.find('D:PF/D:KPF').to_a.size == 0
+          @status = node.find("D:ROR/D:SOR/D:SSU").to_a[0]&.content
+          @ic = node.find('D:ICO').to_a[0]&.content
+          @dic = node.find('D:DIC').to_a[0]&.content
+          @name = node.find('D:OF').to_a[0]&.content
+          @legal_form = node.find('D:PF/D:NPF').to_a[0]&.content
+          @legal_form_id = node.find('D:PF/D:KPF').to_a[0]&.content
 
-          place = node.find('//D:SZ/D:SD/D:T').to_a[0].content unless node.find('//D:SZ/D:SD/D:T').to_a.size == 0
-          record = node.find('//D:SZ/D:OV').to_a[0].content unless node.find('//D:SZ/D:OV').to_a.size == 0
+          place = node.find('//D:SZ/D:SD/D:T').to_a[0]&.content
+          record = node.find('//D:SZ/D:OV').to_a[0]&.content
           section, insert = record.split if record
 
           @case_reference = RubyARES::CaseReference.new(place, section, insert)
@@ -54,13 +52,13 @@ module RubyARES
 
         doc.find('//D:AA').each do |node|
           id = node.find('D:IDA').to_a[0].content
-          street = node.find('D:NU').to_a[0].content unless node.find('D:NU').to_a.size == 0
-          postcode = node.find('D:PSC').to_a[0].content unless node.find('D:PSC').to_a.size == 0
-          city = node.find('D:N').to_a[0].content unless node.find('D:N').to_a.size == 0
-          city_part = node.find('D:NCO').to_a[0].content unless node.find('D:NCO').to_a.size == 0
-          house_number = node.find('D:CD').to_a[0].content unless node.find('D:CD').to_a.size == 0
-          house_number_type = node.find('D:TCD').to_a[0].content unless node.find('D:TCD').to_a.size == 0
-          orientational_number = node.find('D:CO').to_a[0].content unless node.find('D:CO').to_a.size == 0
+          street = node.find('D:NU').to_a[0]&.content
+          postcode = node.find('D:PSC').to_a[0]&.content
+          city = node.find('D:N').to_a[0]&.content
+          city_part = node.find('D:NCO').to_a[0]&.content
+          house_number = node.find('D:CD').to_a[0]&.content
+          house_number_type = node.find('D:TCD').to_a[0]&.content
+          orientational_number = node.find('D:CO').to_a[0]&.content
 
           @addresses << RubyARES::Address.new(id, street, postcode, city, city_part,
                                           house_number, house_number_type, orientational_number)


### PR DESCRIPTION
Set values to `nil` when not present in XML.

Steps to reproduce (before applying this fix):

```
vat_paying_subject = RubyARES::Subject.get(27074358)
non_vat_subject = RubyARES::Subject.get(non_vat_number)

vat_paying_subject.dic == non_vat_subject.dic
=> true
```

Previously, subsequent calls would keep the values of previous calls when not present in new XML.